### PR TITLE
Added parameter to change .env file location

### DIFF
--- a/envcon/configuration.py
+++ b/envcon/configuration.py
@@ -26,6 +26,7 @@ def environment_configuration(
     *,
     prefix: str = "",
     include_dot_env_file: bool = True,
+    dot_env_path: str = ".env",
     frozen: bool = True,
     override_init: bool = True,
     override_repr: bool = True,
@@ -43,13 +44,14 @@ def environment_configuration(
     *,
     prefix: str = "",
     include_dot_env_file: bool = True,
+    dot_env_path: str = ".env",
     frozen: bool = True,
     override_init: bool = True,
     override_repr: bool = True,
 ) -> Union[Class, Callable[[Class], Class]]:
     wrap = configuration(
         prefix=prefix,
-        source=ExtendedEnviron(include_dot_env_file),
+        source=ExtendedEnviron(include_dot_env_file, dot_env_path),
         frozen=frozen,
         override_init=override_init,
         override_repr=override_repr,

--- a/envcon/extended_environ.py
+++ b/envcon/extended_environ.py
@@ -5,8 +5,8 @@ import dotenv
 
 
 class ExtendedEnviron(Mapping[str, str]):
-    def __init__(self, read_dot_env_file: bool) -> None:
-        self._dot_env: Dict[str, Optional[str]] = dotenv.dotenv_values(".env") if read_dot_env_file else {}
+    def __init__(self, read_dot_env_file: bool, dot_env_path: str) -> None:
+        self._dot_env: Dict[str, Optional[str]] = dotenv.dotenv_values(dot_env_path) if read_dot_env_file else {}
 
     def __getitem__(self, key: str) -> str:
         if not isinstance(key, str):


### PR DESCRIPTION
May be useful when the environment file is not in the present working directory, or if its not called `.env`.